### PR TITLE
build(cuda): native RTX 50-series (Blackwell) via CUDA 12.8

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -95,10 +95,10 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # Byte-identical to release.yml (incl. the `-gpuarch2` bump — see the
+          # Byte-identical to release.yml (incl. the `-gpuarch3` bump — see the
           # comment there): the whole point is that the release restores the key
           # this job warms.
-          shared-key: release-${{ matrix.target }}-${{ matrix.features }}-gpuarch2
+          shared-key: release-${{ matrix.target }}-${{ matrix.features }}-gpuarch3
 
       - name: Install system dependencies
         run: |
@@ -114,9 +114,9 @@ jobs:
           echo "${CUDA_KEYRING_SHA256}  cuda-keyring_1.1-1_all.deb" | sha256sum -c -
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-12-4
-          echo "/usr/local/cuda-12.4/bin" >> "$GITHUB_PATH"
-          echo "CUDA_PATH=/usr/local/cuda-12.4" >> "$GITHUB_ENV"
+          sudo apt-get install -y cuda-toolkit-12-8
+          echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
+          echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
 
       - name: Install mold linker
         if: matrix.cuda_linux
@@ -135,4 +135,4 @@ jobs:
           # list), or the warmed cache has a different key than the release
           # build restores. See release.yml for the rationale behind 75 + list.
           CUDA_COMPUTE_CAP: ${{ matrix.cuda_linux && '75' || '' }}
-          CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_linux && '61-real;75-real;80-real;86-real;89-real;90-real;90-virtual' || '' }}
+          CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_linux && '61-real;75-real;80-real;86-real;89-real;90-real;120-real;120-virtual' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
   # (no full toolkit) because cudarc 0.19.4's build script invokes
   # `nvcc --version` even though dynamic-loading dlopens cuda runtime libs
   # at runtime — without nvcc on PATH, `cargo check` fails with
-  # `failed to run custom build command for cudarc`. cuda-nvcc-12-4 is
-  # ~100 MB; the full toolkit (cuda-toolkit-12-4 used in release.yml) is
+  # `failed to run custom build command for cudarc`. cuda-nvcc-12-8 is
+  # ~100 MB; the full toolkit (cuda-toolkit-12-8 used in release.yml) is
   # ~3 GB, which we don't need for `check`. Catches compile errors in any
   # `cfg(feature = "candle-cuda")` or `cfg(feature = "windows-gpu")` code
   # path before a release tag.
@@ -241,8 +241,8 @@ jobs:
           echo "${CUDA_KEYRING_SHA256}  cuda-keyring_1.1-1_all.deb" | sha256sum -c -
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get install -y cuda-nvcc-12-4
-          echo "/usr/local/cuda-12.4/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y cuda-nvcc-12-8
+          echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
       # windows-gpu = ["llama-vulkan", "candle-cuda"]; the llama-vulkan
       # half builds llama-cpp-sys-2's CMake project with -DGGML_VULKAN=ON,
       # which needs Vulkan_LIBRARY, Vulkan_INCLUDE_DIR, and glslc on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,12 +142,13 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # `-gpuarch2`: bumped when the GPU build inputs change in a way cargo
+          # `-gpuarchN`: bumped when the GPU build inputs change in a way cargo
           # can't see. `llama-cpp-sys-2` forwards `CMAKE_CUDA_ARCHITECTURES` to
           # CMake but does NOT `rerun-if-env-changed` on it, so without a key
-          # bump a warm cache would silently ship the previous arch set. Keep
-          # this suffix byte-identical to cache-warm.yml.
-          shared-key: release-${{ matrix.target }}-${{ matrix.features }}-gpuarch2
+          # bump a warm cache would silently ship the previous arch set. Also
+          # bumped for the CUDA 12.4→12.8 toolkit move (native sm_120). Keep this
+          # suffix byte-identical to cache-warm.yml.
+          shared-key: release-${{ matrix.target }}-${{ matrix.features }}-gpuarch3
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -189,9 +190,9 @@ jobs:
           echo "${CUDA_KEYRING_SHA256}  cuda-keyring_1.1-1_all.deb" | sha256sum -c -
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get install -y cuda-toolkit-12-4
-          echo "/usr/local/cuda-12.4/bin" >> "$GITHUB_PATH"
-          echo "CUDA_PATH=/usr/local/cuda-12.4" >> "$GITHUB_ENV"
+          sudo apt-get install -y cuda-toolkit-12-8
+          echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
+          echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
 
       # Linux CUDA release build links 3000+ object files against heavy
       # libraries (libcuda, libcudart, libllama-cpp, libstdc++, …). The
@@ -220,10 +221,15 @@ jobs:
         if: matrix.cuda_windows
         uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
         with:
-          # Pinned to 12.4 — CUDA 13 + RTX 50-series has an open candle bug
-          # (huggingface/candle#3249). Widely-compatible with GeForce drivers
-          # from 2023 onward; the dynamic-loading cudarc features only need
-          # a driver >= the runtime version.
+          # Windows stays on 12.4 while Linux moves to 12.8 — deliberately.
+          # On Windows the only CUDA consumer is candle (llama.cpp uses the
+          # Vulkan backend here), and candle emits PTX that the *driver* JITs to
+          # the actual GPU at runtime, so a Blackwell card already runs on a
+          # 12.4-built candle via its driver — the 12.8 native-sm_120 win is a
+          # llama.cpp/cuBLAS thing that doesn't apply on Windows. Keeping 12.4
+          # also avoids touching the `Jimver@v0.2.19` pin, whose version list may
+          # not include 12.8.0 (and this Windows path isn't PR-validatable — it
+          # only runs on a release tag). Bump both together if that changes.
           cuda: '12.4.0'
           method: 'network'
           # Full set needed for cudarc with `dynamic-loading`: headers for
@@ -346,11 +352,12 @@ jobs:
           # empty panics bindgen_cuda with `ParseIntError { kind: Empty }`.
           CUDA_COMPUTE_CAP: ${{ (matrix.cuda_linux || matrix.cuda_windows) && '75' || '' }}
           # llama.cpp CUDA backend (Linux `cuda` feature only — Windows GPU uses
-          # the Vulkan backend). Native SASS for Pascal→Hopper plus compute_90
-          # PTX so a newer card (Blackwell) still runs via driver JIT. sm_120 is
-          # NOT a native target here because CUDA 12.4's nvcc predates it; the
-          # 12.8 bump that adds native `120-real` is Phase 2 (docs/FUTURE_WORK.md).
-          CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_linux && '61-real;75-real;80-real;86-real;89-real;90-real;90-virtual' || '' }}
+          # the Vulkan backend). Native SASS for Pascal→Blackwell + compute_120
+          # PTX so a future post-Blackwell card still runs via driver JIT. Native
+          # `120-real` needs CUDA 12.8 (nvcc ≥ 12.8 is the first to know sm_120);
+          # research shows the compute_90-PTX-JIT path is up to ~5× slower on the
+          # llama.cpp/cuBLAS Blackwell path, which native SASS avoids.
+          CMAKE_CUDA_ARCHITECTURES: ${{ matrix.cuda_linux && '61-real;75-real;80-real;86-real;89-real;90-real;120-real;120-virtual' || '' }}
 
       - name: Package archive (Linux/macOS)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ All notable changes to SwarmLLM are documented here.
   the very common **RTX 20-series and GTX 16 cards** — quietly fell back to the
   (much slower) processor. It now runs on those cards too, and on the new
   RTX 50-series, so a lot more people get real GPU speed out of the box. Local
-  models also now build for each card generation from GTX 10-series up. (Native,
-  fastest-path support for the RTX 50-series on local models is a follow-up.)
+  models also now build for each card generation from GTX 10-series up, including
+  the RTX 50-series' fastest native code path (which needs the newer CUDA 12.8
+  toolkit — research found the older compatibility path is up to ~5× slower on
+  those cards).
 
 ## [0.3.12-alpha] — 2026-07-23
 


### PR DESCRIPTION
Phase 2 of the GPU-coverage work (Phase 1 — the candle sm_75 floor + llama.cpp arch pin — is already on main and green).

**What this does**
- Linux CUDA toolkit **12.4 → 12.8** (first nvcc that knows sm_120) + adds native **`120-real;120-virtual`** to the local-model (llama.cpp) arch list, so RTX 50-series gets the native fastest path instead of the ~5×-slower PTX-JIT/cuBLAS path.
- **Windows stays on 12.4** deliberately: Windows CUDA is candle-only (PTX → driver-JIT, so Blackwell already works) and llama.cpp there is Vulkan; also avoids the `Jimver@v0.2.19` version-list risk.
- Cache key bumped `gpuarch2 → gpuarch3` so the toolkit+arch change actually takes effect.

**Why a PR:** CI's Linux `Feature compile-check (candle-cuda)` compiles candle against the 12.8 toolkit here, *before* this reaches main. If green, merge; then the `cache-warm` workflow on main is the first thing to exercise the full native-sm_120 llama.cpp build (watched closely — revert the `120` addition if the old bundled llama.cpp rejects the arch).

**Known validation gaps** (can't be tested without hardware / a tag): whether the bundled `llama-cpp-2 0.1` accepts arch `120` (cache-warm covers this post-merge), and runtime correctness on real RTX 50 hardware (Discord testers before any *stable* tag).